### PR TITLE
Upgrade deprecated Expo Function

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,7 +2,8 @@ import I18n from './vendor/i18n';
 import Expo from 'expo';
 
 I18n.initAsync = async () => {
-  const locale = await Expo.Util.getCurrentLocaleAsync();
+  const Localization = Expo.DangerZone.Localization || Expo.Localization || Expo.Util;
+  const locale = await Localization.getCurrentLocaleAsync();
   I18n.locale = (locale) ? locale.replace(/_/, '-') : '';
 }
 


### PR DESCRIPTION
On SDK 26.0.0:
Util.getCurrentLocaleAsync is deprecated, use DangerZone, if avaliable, Localization.getCurrentLocaleAsync to remove Deprecated Warnings
Now Tested